### PR TITLE
Suggested fix for RMSE calculation

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -686,7 +686,7 @@
     "def trace_rmse(x_values, y_values, regression_lines):\n",
     "    errors = root_mean_squared_errors(x_values, y_values, regression_lines)\n",
     "    x_values_bar = list(map(lambda error: 'm: ' + str(error[0]) + ' b: ' + str(error[1]), errors))\n",
-    "    y_values_bar = list(map(lambda error: error[-1], errors))\n",
+    "    y_values_bar = list(map(lambda error: error[0], errors))\n",
     "    return dict(\n",
     "        x=x_values_bar,\n",
     "        y=y_values_bar,\n",


### PR DESCRIPTION
Current version (error[-1]) gives the same RMSE for each trace. Changing to error[0] solves this.